### PR TITLE
Fix hanging bug in MPIMaster/Worker

### DIFF
--- a/src/mpi_master.h
+++ b/src/mpi_master.h
@@ -16,7 +16,7 @@ public:
 
 protected:
     MPI_Comm comm;
-    std::unordered_set<int> working;
+    std::unordered_set<int> workers;
 
     virtual void next_task(nlohmann::json &task) = 0;
     virtual bool task_left() const = 0;

--- a/src/mpi_worker.cc
+++ b/src/mpi_worker.cc
@@ -28,11 +28,11 @@ void MPIWorker::run()
 
             // Work on task
             nlohmann::json result;
-            do_task(result, nlohmann::json::parse(recv_buf));
+            do_task(result, nlohmann::json::from_cbor(recv_buf));
 
             // Send result to master
-            const auto send_buf = result.dump();
-            MPI_Send(send_buf.c_str(), send_buf.size(), MPI_BYTE, 0, TAG_RESULT,
+            const auto send_buf = nlohmann::json::to_cbor(result);
+            MPI_Send(send_buf.data(), send_buf.size(), MPI_BYTE, 0, TAG_RESULT,
                      comm);
 
             // We got a stop message


### PR DESCRIPTION
Fixes potential hangs in worker main loop as well as in MPI_Finalize due to pending messages.

Closes #30.