### PR TITLE
Improve scalability of MPI master

### DIFF
--- a/src/mpi_master.cc
+++ b/src/mpi_master.cc
@@ -4,6 +4,7 @@
 #include "mpi_master.h"
 
 // Based on https://github.com/nepda/pi-pp/blob/master/serie_4
+// clang-format off
 void MPIMaster::run()
 {
     nlohmann::json task;
@@ -21,44 +22,47 @@ void MPIMaster::run()
         workers.insert(worker);
     }
 
-    while (task_left() || !workers.empty()) {
-        // Wait for any incomming message
-        MPI_Probe(MPI_ANY_SOURCE, MPI_ANY_TAG, comm, &stat);
+    #pragma omp parallel
+    {
+        #pragma omp master
+        while (task_left() || !workers.empty()) {
+            // Wait for any incomming message
+            MPI_Probe(MPI_ANY_SOURCE, MPI_ANY_TAG, comm, &stat);
 
-        // Store rank of receiver into worker
-        const auto worker = stat.MPI_SOURCE;
+            const auto worker = stat.MPI_SOURCE;
 
-        // Worker asked for a task
-        if (stat.MPI_TAG == TAG_ASK_FOR_TASK) {
-            MPI_Recv(nullptr, 0, MPI_BYTE, worker, TAG_ASK_FOR_TASK, comm,
-                     &stat);
-
-            if (task_left()) {
-                next_task(task);
-
-                const auto send_buf = nlohmann::json::to_cbor(task);
-                // We have unprocessed tasks, we send one task to the worker
-                MPI_Send(send_buf.data(), send_buf.size(), MPI_BYTE, worker,
-                         TAG_TASK_DATA, comm);
-            } else {
-                // Send stop msg to worker
-                MPI_Send(nullptr, 0, MPI_BYTE, worker, TAG_STOP, comm);
-
-                workers.erase(worker);
-            }
-        }
-        // Worker sent result
-        else if (stat.MPI_TAG == TAG_RESULT) {
             auto count = 0;
             MPI_Get_count(&stat, MPI_BYTE, &count);
 
             std::vector<uint8_t> recv_buf(count);
 
-            // We got a result message
-            MPI_Recv(recv_buf.data(), count, MPI_BYTE, worker, TAG_RESULT, comm,
-                     &stat);
+            MPI_Recv(recv_buf.data(), recv_buf.size(), MPI_BYTE, worker,
+                     stat.MPI_TAG, comm, &stat);
 
-            task_done(nlohmann::json::from_cbor(recv_buf));
+            // Worker asked for a task
+            if (stat.MPI_TAG == TAG_ASK_FOR_TASK) {
+                if (!task_left()) {
+                    workers.erase(worker);
+                    continue;
+                }
+
+                next_task(task);
+                const auto send_buf = nlohmann::json::to_cbor(task);
+
+                MPI_Send(send_buf.data(), send_buf.size(), MPI_BYTE, worker,
+                         TAG_TASK_DATA, comm);
+            }
+            // Worker sent result
+            else if (stat.MPI_TAG == TAG_RESULT) {
+                #pragma omp task firstprivate(recv_buf)
+                task_done(nlohmann::json::from_cbor(recv_buf));
+            }
         }
     }
+
+    for (auto worker = 1; worker < comm_size; worker++) {
+        // Send stop msg to worker
+        MPI_Send(nullptr, 0, MPI_BYTE, worker, TAG_STOP, comm);
+    }
 }
+// clang-format on


### PR DESCRIPTION
Improves the scalability of MPI master by offloading the deserialization of received messages and subsequent processing onto worker threads. Note that `MPIMaster::task_done()` needs to be thread-safe after this PR.